### PR TITLE
Tracks order of nodes even when they have no parents (Node extension)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.0-dev.388+05e217607",
     .dependencies = .{
         .slot_map = .{
-            .url = "git+https://github.com/Games-By-Mason/SlotMap#6e48aef4d8eba97a19648a8ef2ef870640e3be89",
-            .hash = "slot_map-0.0.0-xUe6_P9LAADyOAbtOkdbKklpyysJ-Ar1fchuvkL0TT04",
+            .url = "git+https://github.com/Games-By-Mason/SlotMap#fd2abfa97c2429c15015992e11da4b38196f0b9f",
+            .hash = "slot_map-0.0.0-xUe6_GFMAACqypMFJeDpzVlnJ_Rab4CfrDiEMyzXnBFb",
         },
         // Only used by extensions
         .geom = .{

--- a/src/ext/Node.zig
+++ b/src/ext/Node.zig
@@ -117,7 +117,7 @@ pub fn setParentImmediate(self: *Node, es: *Entities, tr: *Tree, parent_opt: ?*N
 }
 
 /// Similar to the `Insert`, but makes the change immediately.
-pub fn insert(
+pub fn insertImmediate(
     self: *Node,
     es: *Entities,
     tr: *Tree,
@@ -539,7 +539,7 @@ pub const Exec = struct {
             if (self_node) |self| {
                 if (other_node) |other| {
                     // Set up the relationship
-                    self.insert(es, tr, std.meta.activeTag(args.position), other);
+                    self.insertImmediate(es, tr, std.meta.activeTag(args.position), other);
                 } else {
                     // Other has since been deleted, destroy the child
                     self.destroyImmediate(es, tr);

--- a/tests/ext/node.zig
+++ b/tests/ext/node.zig
@@ -569,7 +569,7 @@ fn insert(fz: *Fuzzer, tr: *Node.Tree, o: *Oracle) !void {
         try o.roots.put(gpa, other, {});
     }
 
-    self_node.insert(&fz.es, tr, relative, other_node);
+    self_node.insertImmediate(&fz.es, tr, relative, other_node);
     try insertInOracle(fz, o, self, relative, other);
 }
 

--- a/tests/ext/transform.zig
+++ b/tests/ext/transform.zig
@@ -43,6 +43,8 @@ test "exec" {
     });
     defer es.deinit(gpa);
 
+    var tr: Node.Tree = .empty;
+
     var cb: CmdBuf = try .init(.{
         .name = null,
         .gpa = gpa,
@@ -59,7 +61,7 @@ test "exec" {
     const child: Entity = .reserve(&cb);
     const parent: Entity = .reserve(&cb);
     cb.ext(SetParent, .{ .child = child, .parent = parent.toOptional() });
-    Transform.Exec.immediate(&es, &cb);
+    Transform.Exec.immediate(&es, &cb, &tr);
 
     const child_node = child.get(&es, Node).?;
     try expectEqual(child_node.parent, parent.toOptional());
@@ -92,6 +94,8 @@ fn fuzzTransformsCmdBuf(_: void, input: []const u8) !void {
         },
     });
     defer es.deinit(gpa);
+
+    var tr: Node.Tree = .empty;
 
     var cb: CmdBuf = try .init(.{
         .name = null,
@@ -248,7 +252,7 @@ fn fuzzTransformsCmdBuf(_: void, input: []const u8) !void {
             },
         }
 
-        Transform.Exec.immediate(&es, &cb);
+        Transform.Exec.immediate(&es, &cb, &tr);
         try checkOracle(&es);
     }
 }

--- a/tests/unit.zig
+++ b/tests/unit.zig
@@ -1063,11 +1063,11 @@ test "cb capacity" {
 }
 
 test "format entity" {
-    try std.testing.expectFmt("0xa:0xb", "{f}", Entity{ .key = .{
+    try std.testing.expectFmt("0xA:B", "{f}", Entity{ .key = .{
         .index = 10,
         .generation = @enumFromInt(11),
     } });
-    try std.testing.expectFmt("0xa:0xb", "{f}", (Entity{ .key = .{
+    try std.testing.expectFmt("0xA:B", "{f}", (Entity{ .key = .{
         .index = 10,
         .generation = @enumFromInt(11),
     } }).toOptional());


### PR DESCRIPTION
This only affects users of the `zcs.ext.Node` extension.

When nodes are stored as children, they have a well defined order as set by the sibling linked list. However, prior to this PR, nodes with no parents have no relative order. This causes two major issues:

1. You may reasonably want game logic to depend on node order, but this concept ceases to exist when you unparent a node. This makes it hard to create good abstractions around node order.
2. Similarly, if you attempt to create a hierarchy style UI for editing entities, you can reorder entities in the hierarchy unless they're at the root. This is not expected, I've never seen a UI that works this way.

To solve this, this PR introduces `Node.Tree` which only has as single field `first_child`, this provides an implicit root for all nodes, thereby assigning an order to all nodes. The caller must store this value, but it is kept in sync automatically via the existing API.

In addition, this PR introduces a new primitive:
* `Node.insertImmediate` / `Node.Insert`

Now that all nodes have an order, you can use this to insert a node to a specific location in the node tree. Unlike set parent, you can insert before or after a specific sibling node using this primitive.

This PR also cleans up how entities are formatted a bit.